### PR TITLE
Add notice-on-cloak

### DIFF
--- a/cloaks/__init__.py
+++ b/cloaks/__init__.py
@@ -114,10 +114,15 @@ class Server(BaseServer):
         elif (line.command == "CHGHOST" and
                 line.params[1].startswith("user/")):
 
+            newcloak = line.params[1]
             await self.send(build("KICK", [
                 self._config.channel,
                 line.hostmask.nickname,
                 "You've been cloaked"]
+            ))
+            await self.send(build("NOTICE", [
+                line.hostmask.nickname,
+                f"Your new cloak is `{newcloak}`. Remember to use SASL to ensure you're always cloaked."]
             ))
 
     async def _cloak(self, user: User):

--- a/cloaks/__init__.py
+++ b/cloaks/__init__.py
@@ -114,16 +114,22 @@ class Server(BaseServer):
         elif (line.command == "CHGHOST" and
                 line.params[1].startswith("user/")):
 
-            newcloak = line.params[1]
             await self.send(build("KICK", [
                 self._config.channel,
                 line.hostmask.nickname,
                 "You've been cloaked"]
             ))
-            await self.send(build("NOTICE", [
-                line.hostmask.nickname,
-                f"Your new cloak is `{newcloak}`. Remember to use SASL to ensure you're always cloaked."]
-            ))
+
+            cloak = line.params[1]
+            channel = self._config.channel
+            nick = line.hostmask.nickname
+            message = self._config.substitute_safe(cloak=cloak, channel=channel, nick=nick)
+
+            if message:
+                await self.send(build("NOTICE", [
+                    nick,
+                    message]
+                ))
 
     async def _cloak(self, user: User):
         account = user.account

--- a/cloaks/__init__.py
+++ b/cloaks/__init__.py
@@ -117,19 +117,19 @@ class Server(BaseServer):
             await self.send(build("KICK", [
                 self._config.channel,
                 line.hostmask.nickname,
-                "You've been cloaked"]
-            ))
+                "You've been cloaked"
+            ]))
 
             cloak = line.params[1]
             channel = self._config.channel
             nick = line.hostmask.nickname
-            message = self._config.substitute_safe(cloak=cloak, channel=channel, nick=nick)
+            message = self._config.message.substitute_safe(cloak=cloak, channel=channel, nick=nick)
 
             if message:
                 await self.send(build("NOTICE", [
                     nick,
-                    message]
-                ))
+                    message
+                ]))
 
     async def _cloak(self, user: User):
         account = user.account

--- a/cloaks/config.py
+++ b/cloaks/config.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from os.path     import expanduser
 from re          import compile as re_compile
+from string      import Template
 from typing      import List, Pattern, Tuple
 
 import yaml
@@ -13,6 +14,7 @@ class Config(object):
     realname: str
     password: str
     channel:  str
+    message:  Template
 
     sasl: Tuple[str, str]
     oper: Tuple[str, str]
@@ -22,6 +24,7 @@ def load(filepath: str):
         config_yaml = yaml.safe_load(file.read())
 
     nickname = config_yaml["nickname"]
+    message  = Template(config_yaml["message"] or "")
 
     server   = config_yaml["server"]
     hostname, port_s = server.split(":", 1)

--- a/cloaks/config.py
+++ b/cloaks/config.py
@@ -24,7 +24,7 @@ def load(filepath: str):
         config_yaml = yaml.safe_load(file.read())
 
     nickname = config_yaml["nickname"]
-    message  = Template(config_yaml["message"] or "")
+    message  = Template(config_yaml.get("message", ""))
 
     server   = config_yaml["server"]
     hostname, port_s = server.split(":", 1)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,6 +2,7 @@ server: irc.libera.chat:+6697
 nickname: cloaks
 password: cloaks:hunter2
 channel: "#libera-cloak"
+message: "Your new cloak is $cloak"
 
 sasl:
   username: cloaks


### PR DESCRIPTION
Quoth `#libera` on September the 13th, in the year 2022:
```
<arraybolt3> Wait - asking for a cloak on #libera-cloak results in receiving one and then you're auto-banned from the channel?
<catties> yes.
<catties> once you have a cloak, you no longer need to be in there
<@Bahhumbug> Banned and kick.  The kick message should indicate your cloak was set but some clients just nuke the buffer/window on a kick so...
<catties> couldn't the bot also send a notice?
<arraybolt3> Hmm, I guess it makes logical sense, just kind of alarming that a ban and kick is normal behavior and not the result of getting in trouble :P
<@Bahhumbug> catties: It could.  You could file a PR against https://github.com/Libera-Chat/cloaks if you wish.
<@Bahhumbug> Volunteers in a volunteer project only have so much time to devote to it; public contributions of any sort (code, documentation, whathaveyou) are always going to be welcome.
<She> Actually. catties: Do you have any plans to make that PR?
<catties> i was thinking about it, it doesn't look too hard
<catties> but i'm also ridiculously busy, so be my guest if you want to go ahead
```

This PR theoretically makes the cloak bot send a notice after it kicks on `CHGHOST`. The notice also includes a little reminder to use SASL, which is less of a stumbling point for novices than it used to be, but ever so often I still see people with accounts who aren't identified prior to joining channels.